### PR TITLE
context-color: remove `bc` dependency

### DIFF
--- a/context-color
+++ b/context-color
@@ -98,10 +98,9 @@ __context_color_hash() {
     if [ "$CC_METHOD" = "md5sum" ]
     then
         hash=$(eval "$CC_CONTEXT" | md5sum | head -c 6 | tr '[:lower:]' '[:upper:]')
-        echo "ibase=16; $hash" | bc
+        echo "$((16#$hash))"
     else
         hash=$(eval "$CC_CONTEXT" | sum | cut -d' ' -f1)
-        echo "obase=10; $hash" | bc
     fi
 }
 

--- a/context-color
+++ b/context-color
@@ -101,6 +101,7 @@ __context_color_hash() {
         echo "$((16#$hash))"
     else
         hash=$(eval "$CC_CONTEXT" | sum | cut -d' ' -f1)
+        echo "$((10#$hash))"
     fi
 }
 


### PR DESCRIPTION
Use Bourne Shell compatible $((16#...)) syntax instead, to convert from base 16 to base 10